### PR TITLE
Fix Relationship.instances cache.

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -100,11 +100,13 @@ module Axlsx
     #   File.open('example_streamed.xlsx', 'w') { |f| f.write(s.read) }
     def serialize(output, confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
-      Relationship.clear_cached_instances
+      Relationship.initialize_cached_instances
       Zip::OutputStream.open(output) do |zip|
         write_parts(zip)
       end
       true
+    ensure
+      Relationship.clear_cached_instances
     end
 
 
@@ -113,11 +115,13 @@ module Axlsx
     # @return [StringIO|Boolean] False if confirm_valid and validation errors exist. rewound string IO if not.
     def to_stream(confirm_valid=false)
       return false unless !confirm_valid || self.validate.empty?
-      Relationship.clear_cached_instances
+      Relationship.initialize_cached_instances
       zip = write_parts(Zip::OutputStream.new(StringIO.new, true))
       stream = zip.close_buffer
       stream.rewind
       stream
+    ensure
+      Relationship.clear_cached_instances
     end
 
     # Encrypt the package into a CFB using the password provided


### PR DESCRIPTION
> marshall-lee commented on 3 Aug 2016

> This PR aims to fix several issues with Relationship cache:
> 
> 1. It's not threadsafe, so I propose to use a TLS variable for this.
> 2. Memory obtained by cache remains non-freed before the next run of `serialize`. I think it should be freed immediately.
> 3. Memory should be freed in `ensure` block to prevent memory bloating in case of exception.
> 
> _There are only two hard things in Computer Science: cache invalidation and naming things._